### PR TITLE
Ropes issue4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'jquery-rails'
 
 gem 'webpacker', '~> 4'
 
+gem 'acts-as-taggable-on', '~> 6.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (6.5.0)
+      activerecord (>= 5.0, < 6.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
@@ -224,6 +226,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 6.0)
   byebug
   capybara
   jquery-rails

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -12,7 +12,7 @@ class ImagesController < ActionController::Base
   end
 
   def create
-    @image = Image.new(url: image_params[:url])
+    @image = Image.new(image_params)
     if @image.valid?
       @image.save!
       flash[:notice] = 'Image url saved successfully'
@@ -26,6 +26,6 @@ class ImagesController < ActionController::Base
   private
 
   def image_params
-    params.require(:image).permit(:url)
+    params.require(:image).permit(:url, :tag_list)
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,4 +1,5 @@
 class Image < ApplicationRecord
   VALID_URL = %r{\A(http(s?):)([/|.|\w|\s|-])*\.(?:jpg|gif|png|jpeg)\z}.freeze
   validates(:url, presence: true, format: { with: VALID_URL })
+  acts_as_taggable
 end

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -7,6 +7,7 @@
       <tr class = "js-image-card">
         <td>
           <%= image_tag image.url, size: "300x300" %>
+          <%= image.tag_list&.join(', ') %>
         </td>
       </tr>
     <% end %>

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -9,7 +9,10 @@
       <%= f.label :url %>
       <%= f.text_field :url, class: 'form-control' %>
 
-      <%= f.submit "Submit Image Link", class: "btn btn-primary", id: "Button123" %>
+      <%= f.label :tag, 'Image Tags', id: "image_tag_label" %>
+      <%= f.text_field :tag_list %>
+
+      <%= f.submit "Submit Image Link", class: "btn btn-primary", id: "button_123" %>
     <% end %>
   </div>
 </div>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -8,6 +8,12 @@
           No image found!
         <% end %>
       </h1>
+      <% if @image %>
+        <p>
+          Tag: <br>
+          <span class="js_image_tag"><%= @image&.tag_list.join(', ') %></span>
+        </p>
+      <% end %>
     </section>
   </aside>
 </div>

--- a/db/migrate/20200622050143_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200622050143_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,37 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20200622050144_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200622050144_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20200622050145_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200622050145_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20200622050146_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200622050146_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20200622050147_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200622050147_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20200622050148_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200622050148_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_16_230827) do
+ActiveRecord::Schema.define(version: 2020_06_22_050148) do
 
   create_table "images", force: :cascade do |t|
     t.string "url", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -23,6 +23,50 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_select 'td', 'tag1'
   end
 
+  def test_show_success
+    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
+    valid_tag = 'test'
+    image = Image.create!(url: valid_image_url, tag_list: valid_tag)
+    get image_path(image)
+    assert_response :ok
+    assert_includes response.body, valid_image_url
+    assert_equal Image.last.url, valid_image_url
+    assert_equal Image.last.tag_list, [valid_tag]
+    assert_select '.js_image_tag', valid_tag
+  end
+
+  def test_show_empty_tag
+    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
+    valid_tag = ''
+    image = Image.create!(url: valid_image_url, tag_list: valid_tag)
+    get image_path(image)
+    assert_response :ok
+    assert_includes response.body, valid_image_url
+    assert_equal Image.last.url, valid_image_url
+    assert_equal Image.last.tag_list, []
+    assert_select '.js_image_tag', valid_tag
+  end
+
+  def test_show_no_tag
+    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
+    image = Image.create!(url: valid_image_url, tag_list: nil)
+    get image_path(image)
+    assert_response :ok
+    assert_includes response.body, valid_image_url
+    assert_equal Image.last.url, valid_image_url
+    assert_equal Image.last.tag_list, []
+    assert_select '.js_image_tag', nil
+  end
+
+  def test_show_many_tags
+    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
+    valid_tags = %w[test1 test2]
+    image = Image.create!(url: valid_image_url, tag_list: valid_tags)
+    get image_path(image)
+    assert_response :ok
+    assert_select '.js_image_tag', valid_tags.join(', ')
+  end
+
   def test_show_image_not_found
     get '/images/asdf'
     assert_includes response.body, 'No image found!'

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -1,5 +1,28 @@
 require 'test_helper'
 class ImagesControllerTest < ActionDispatch::IntegrationTest
+  def test_index
+    images = [
+      { url: 'https://www.gstatic.com/webp/gallery3/1.png',
+        tag_list: 'tag1' },
+      { url: 'https://www.gstatic.com/webp/gallery3/2.png',
+        tag_list: 'tag2' }
+    ]
+    Image.create!(images)
+    get images_path
+    assert_response :ok
+    assert_select 'img', 2 do |image|
+      assert image[0].attributes['width'].value.to_i <= 400
+      assert image[1].attributes['width'].value.to_i <= 400
+      assert_equal 'https://www.gstatic.com/webp/gallery3/2.png',
+                   image[0].attributes['src'].value
+      assert_equal 'https://www.gstatic.com/webp/gallery3/1.png',
+                   image[1].attributes['src'].value
+    end
+    assert_select 'tr', 2
+    assert_select 'td', 'tag2'
+    assert_select 'td', 'tag1'
+  end
+
   def test_show_image_not_found
     get '/images/asdf'
     assert_includes response.body, 'No image found!'

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -1,14 +1,5 @@
 require 'test_helper'
 class ImagesControllerTest < ActionDispatch::IntegrationTest
-  def test_show_success
-    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
-    image = Image.create!(url: valid_image_url)
-    get image_path(image)
-    assert_response :ok
-    assert_includes response.body, valid_image_url
-    assert_equal Image.last.url, valid_image_url
-  end
-
   def test_show_image_not_found
     get '/images/asdf'
     assert_includes response.body, 'No image found!'
@@ -37,6 +28,8 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_includes response.body, 'Image Link Form'
     assert_select '.btn-primary'
-    assert_select '#Button123'
+    assert_select '#button_123'
+    assert_select '#image_tag_list'
+    assert_select '#image_tag_label'
   end
 end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -21,4 +21,31 @@ class ImageTest < ActiveSupport::TestCase
     Rails.application.load_seed
     assert_equal Image.count, 10
   end
+
+  def test_tag
+    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
+    tag = 'tag1'
+    image = Image.create!(url: valid_image_url, tag_list: tag)
+    assert_equal image.tag_list, [tag]
+  end
+
+  def test_tags
+    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
+    tags = 'tag1,tag2'
+    image = Image.create!(url: valid_image_url, tag_list: tags)
+    assert_equal image.tag_list, %w(tag1 tag2)
+  end
+
+  def test_empty_tag
+    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
+    tag = ''
+    image = Image.create!(url: valid_image_url, tag_list: tag)
+    assert_equal image.tag_list, []
+  end
+
+  def test_no_tag
+    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
+    image = Image.create!(url: valid_image_url, tag_list: nil)
+    assert_equal image.tag_list, []
+  end
 end


### PR DESCRIPTION
Added and applied the acts_as_taggable gem with the necessary database migrations. Images New page now includes a form field for inputting tags, separated by commas. All images display tags on Index and Show pages.