### PR TITLE
Ropes issue5

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,6 +1,11 @@
 class ImagesController < ActionController::Base
   def index
-    @images = Image.all.order(created_at: :desc)
+    image_tags = params.permit(:tag)[:tag]
+    if image_tags.nil?
+      @images = Image.all.order(created_at: :desc)
+    else
+      @images = Image.tagged_with(image_tags).order(created_at: :desc)
+    end
   end
 
   def show

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -7,7 +7,9 @@
       <tr class = "js-image-card">
         <td>
           <%= image_tag image.url, size: "300x300" %>
-          <%= image.tag_list&.join(', ') %>
+          <% image.tag_list&.each do |t| %>
+            <li><%= link_to t, images_path(tag: t) %></li>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -11,7 +11,9 @@
       <% if @image %>
         <p>
           Tag: <br>
-          <span class="js_image_tag"><%= @image&.tag_list.join(', ') %></span>
+          <span class="js-image-tag">
+            <%= raw(@image.tag_list.map { |t| link_to t, images_path(tag: t) }.join(', ')) %>
+          </span>
         </p>
       <% end %>
     </section>

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -1,5 +1,53 @@
 require 'test_helper'
+
+VALID_IMAGE_URL = 'https://www.gstatic.com/webp/gallery3/1.png'.freeze
+
 class ImagesControllerTest < ActionDispatch::IntegrationTest
+  def test_filter_many_tags
+    tag_1 = 'tag1'
+    tag_many = %w[tag1 tag2]
+    Image.create!(url: VALID_IMAGE_URL, tag_list: tag_many)
+    get "/images/?tag=#{tag_1}"
+    assert_select '.js-image-card', 1
+  end
+
+  def test_filter_different_tags
+    tag_1 = 'tag1'
+    tag_2 = 'tag2'
+    Image.create!(url: VALID_IMAGE_URL, tag_list: tag_1)
+    get "/images/?tag=#{tag_1}"
+    assert_select '.js-image-card', 1
+    Image.create!(url: VALID_IMAGE_URL, tag_list: tag_2)
+    get "/images/?tag=#{tag_2}"
+    assert_select '.js-image-card', 1
+  end
+
+  def test_filter_same_tags
+    tag = 'test'
+    Image.create!(url: VALID_IMAGE_URL, tag_list: tag)
+    get "/images/?tag=#{tag}"
+    assert_select '.js-image-card', 1
+    Image.create!(url: VALID_IMAGE_URL, tag_list: tag)
+    get "/images/?tag=#{tag}"
+    assert_select '.js-image-card', 2
+  end
+
+  def test_filter_no_tag_match
+    tag_many = %w[tag1 tag2]
+    Image.create!(url: VALID_IMAGE_URL, tag_list: tag_many)
+    get images_url(tag: 'tag3')
+    assert_select '.js-image-card', count: 0
+  end
+
+  def test_filter_empty_tag
+    empty_tag = []
+    other_tag = 'other'
+    Image.create!(url: VALID_IMAGE_URL, tag_list: empty_tag)
+    Image.create!(url: VALID_IMAGE_URL, tag_list: other_tag)
+    get images_url(tag: empty_tag)
+    assert_select '.js-image-card', 2
+  end
+
   def test_index
     images = [
       { url: 'https://www.gstatic.com/webp/gallery3/1.png',
@@ -24,47 +72,43 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_show_success
-    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
     valid_tag = 'test'
-    image = Image.create!(url: valid_image_url, tag_list: valid_tag)
+    image = Image.create!(url: VALID_IMAGE_URL, tag_list: valid_tag)
     get image_path(image)
     assert_response :ok
-    assert_includes response.body, valid_image_url
-    assert_equal Image.last.url, valid_image_url
+    assert_includes response.body, VALID_IMAGE_URL
+    assert_equal Image.last.url, VALID_IMAGE_URL
     assert_equal Image.last.tag_list, [valid_tag]
-    assert_select '.js_image_tag', valid_tag
+    assert_select '.js-image-tag', valid_tag
   end
 
   def test_show_empty_tag
-    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
     valid_tag = ''
-    image = Image.create!(url: valid_image_url, tag_list: valid_tag)
+    image = Image.create!(url: VALID_IMAGE_URL, tag_list: valid_tag)
     get image_path(image)
     assert_response :ok
-    assert_includes response.body, valid_image_url
-    assert_equal Image.last.url, valid_image_url
+    assert_includes response.body, VALID_IMAGE_URL
+    assert_equal Image.last.url, VALID_IMAGE_URL
     assert_equal Image.last.tag_list, []
-    assert_select '.js_image_tag', valid_tag
+    assert_select '.js-image-tag', valid_tag
   end
 
   def test_show_no_tag
-    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
-    image = Image.create!(url: valid_image_url, tag_list: nil)
+    image = Image.create!(url: VALID_IMAGE_URL, tag_list: nil)
     get image_path(image)
     assert_response :ok
-    assert_includes response.body, valid_image_url
-    assert_equal Image.last.url, valid_image_url
+    assert_includes response.body, VALID_IMAGE_URL
+    assert_equal Image.last.url, VALID_IMAGE_URL
     assert_equal Image.last.tag_list, []
-    assert_select '.js_image_tag', nil
+    assert_select '.js-image-tag', nil
   end
 
   def test_show_many_tags
-    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
     valid_tags = %w[test1 test2]
-    image = Image.create!(url: valid_image_url, tag_list: valid_tags)
+    image = Image.create!(url: VALID_IMAGE_URL, tag_list: valid_tags)
     get image_path(image)
     assert_response :ok
-    assert_select '.js_image_tag', valid_tags.join(', ')
+    assert_select '.js-image-tag', valid_tags.join(', ')
   end
 
   def test_show_image_not_found
@@ -73,18 +117,17 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_create
-    valid_image_url = 'https://www.gstatic.com/webp/gallery3/1.png'
     assert_difference 'Image.count' do
-      post images_path, params: { image: { url: valid_image_url } }
+      post images_path, params: { image: { url: VALID_IMAGE_URL } }
     end
     assert_equal 'Image url saved successfully', flash[:notice]
     assert_redirected_to image_path(Image.last)
   end
 
   def test_invalid_create
-    invalid_image_url = 'asdf'
+    inVALID_IMAGE_URL = 'asdf'
     assert_no_difference 'Image.count' do
-      post images_path, params: { image: { url: invalid_image_url } }
+      post images_path, params: { image: { url: inVALID_IMAGE_URL } }
     end
     assert_equal 'Invalid Url!', flash[:error]
     assert_redirected_to new_image_path


### PR DESCRIPTION
Allow images to be filtered according to tag name. Clicking on the tag link of an image on the Index or Show page displays a filtered list of images, all with at least one matching tag.